### PR TITLE
Add Maximum Cache Age Feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *.egg-info/
 *.xml
-.coverage
+.coverage*
 .tox
 .venv
 .mypy_cache

--- a/tests/test_maxage.py
+++ b/tests/test_maxage.py
@@ -1,0 +1,105 @@
+"""Age Testing."""
+import datetime
+import time
+
+import pytest
+
+from anycache import AnyCache
+
+
+def test_maxage_none():
+    """Disable maximum age check."""
+    ac = AnyCache(maxage=None)
+
+    @ac.anycache()
+    def myfunc(posarg, kwarg=3):
+        # count the number of calls
+        myfunc.callcount += 1
+        return posarg + kwarg
+
+    myfunc.callcount = 0
+
+    assert myfunc(4, 5) == 9
+    assert myfunc.callcount == 1
+    time.sleep(5)
+    assert myfunc(4, 5) == 9
+    assert myfunc.callcount == 1
+
+@pytest.mark.parametrize(
+    argnames=("maxage_seconds", "wait_seconds"),
+    argvalues=[
+        (1, 5),
+        (2, 5),
+        (3, 5),
+    ]
+)
+def test_maxage_expired_cache(
+    maxage_seconds: int,
+    wait_seconds: int,
+    threshold_seconds: int = 1,
+):
+    """Small, basic maximum age check."""
+    ac = AnyCache(maxage=datetime.timedelta(seconds=maxage_seconds))
+
+    @ac.anycache()
+    def myfunc():
+        # count the number of calls
+        myfunc.callcount += 1
+        return datetime.datetime.now(tz=datetime.UTC)
+
+    myfunc.callcount = 0
+
+    # Ensure that the returned datetime value is within the acceptable threshold from
+    # when the function was invoked and that the function was invoked once.
+    difference = datetime.datetime.now(tz=datetime.UTC) - myfunc()
+    assert difference <= datetime.timedelta(seconds=threshold_seconds)
+    assert myfunc.callcount == 1
+
+    # Wait the given amount of time.
+    time.sleep(wait_seconds)
+
+    # Ensure that the returned datetime value is within the acceptable threshold from
+    # when the function was invoked and that the function was invoked a second time.
+    difference = datetime.datetime.now(tz=datetime.UTC) - myfunc()
+    assert difference <= datetime.timedelta(seconds=threshold_seconds)
+    assert myfunc.callcount == 2
+
+@pytest.mark.parametrize(
+    argnames=("maxage_seconds", "wait_seconds"),
+    argvalues=[
+        (60, 1),
+        (60, 2),
+        (60, 3),
+    ]
+)
+def test_maxage_nonexpired_cache(
+    maxage_seconds: int,
+    wait_seconds: int,
+    threshold_seconds: int = 1,
+):
+    """Small, basic maximum age check."""
+    ac = AnyCache(maxage=datetime.timedelta(seconds=maxage_seconds))
+
+    @ac.anycache()
+    def myfunc():
+        # count the number of calls
+        myfunc.callcount += 1
+        return datetime.datetime.now(tz=datetime.UTC)
+
+    myfunc.callcount = 0
+
+    # Ensure that the returned datetime value is within the acceptable threshold from
+    # when the function was invoked and that the function was invoked once.
+    now = datetime.datetime.now(tz=datetime.UTC)
+    difference = now - myfunc()
+    assert difference <= datetime.timedelta(seconds=threshold_seconds)
+    assert myfunc.callcount == 1
+
+    # Wait the given amount of time.
+    time.sleep(wait_seconds)
+
+    # Ensure that the returned datetime value is within the acceptable threshold from
+    # when the function was invoked and that the function was still only invoked once.
+    difference = now - myfunc()
+    assert difference <= datetime.timedelta(seconds=threshold_seconds)
+    assert myfunc.callcount == 1


### PR DESCRIPTION
In response to #5, this PR adds a maximum cache age feature, along with unit tests for it.

This PR adds a new parameter to the `anycache` constructor: `maxage`, which is an optional `datetime.timedelta` object that represents the maximum age a cache entry is allowed to live for. Setting this parameter (or leaving it as the default) to `None` disables the cache maximum age check. Otherwise the cache entry's file's `st_mtime` (time of last modification) is compared to the current time and the difference is then compared to the allowed maximum age of the cache entry. If the difference is greater than the allowed maximum age, the cache entry is marked as outdated.

Coverage for the `anycache` package remains at 100%.
```
-------- coverage: platform linux, python 3.11.0-candidate-1 ---------
Name                   Stmts   Miss  Cover
------------------------------------------
anycache/__init__.py     218      0   100%
------------------------------------------
TOTAL                    218      0   100%
```